### PR TITLE
Add text to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Gonum floats
+
+package floats provides a set of helper routines for dealing with slices of float64. The functions avoid allocations to allow for use within tight loops without garbage collection overhead.
+
+## Issues
+
+If you find any bugs, feel free to file an issue on the github issue tracker. Discussions on API changes, added features, code review, or similar requests are preferred on the gonum-dev Google Group.
+
+https://groups.google.com/forum/#!forum/gonum-dev
+
+## License
+
+Please see github.com/gonum/license for general license information, contributors, authors, etc on the Gonum suite of packages.


### PR DESCRIPTION
README.md was blank, which means the package didn't have an obvious license.
