### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,21 @@
 language: go
+
+go:
+ - release
+ - tip
+
+ script:
+  - go get -d -v ./...
+  - go build -x -v ./...
+  - go test -x -v ./...
+  - diff <(gofmt -d .) <("")
+
+ after_failure: failure
+ after_error: failure
+
+ notifications:
+   email:
+     recipients:
+       - jonathan.lawlor@gmail.com
+     on_success: change
+     on_failure: always


### PR DESCRIPTION
This contains a simple version of .travis.yml for go.

After it is merged, it will still require activation from the travis-ci.com side.  Doing so is straightforward.
