### PR TITLE
Use range instead of traditional for loop

### DIFF
--- a/floats.go
+++ b/floats.go
@@ -671,9 +671,9 @@ func Within(s []float64, v float64) int {
 	if v < s[0] || v >= s[len(s)-1] || math.IsNaN(v) {
 		return -1
 	}
-	for i := 1; i < len(s); i++ {
-		if v < s[i] {
-			return i - 1
+	for i, f := range s[1:] {
+		if v < f {
+			return i
 		}
 	}
 	return -1


### PR DESCRIPTION
This should be faster and is a little easier to read. It also shows that while semantically difficult (I have left previous behaviour) it is now possible to relax len(s) restriction since when len(s) == 1, the for loop is a no-op. Depending on how you interpret s[i] <= v < s[i+1], it is either valid (but empty) or panicable.
