### PR TITLE
only do coveralls when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
  - go build -v ./...
  - go test -v -covermode=count -coverprofile=coverage.out
  - diff <(gofmt -d .) <("")
- - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+ - if [[ $TRAVIS_SECURE_ENV_VARS ]]; then $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN; fi
 
 after_failure: failure
 


### PR DESCRIPTION
Travis only gives secure environment variables when the origin and
target repo are the same in a pull request.  We shouldn’t break the CI
when coverage isn’t available.
