### PR TITLE
Add a few higher order functions

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -119,7 +119,7 @@ func ExampleFilter_simple() {
 	// s = [1 3 2 5 6]
 }
 
-func ExampleFilter_susequence() {
+func ExampleFilter_subsequence() {
 	// Let's use state magic to filter elements
 	// so the resulting list is a strictly increasing
 	// subsequence!
@@ -135,7 +135,7 @@ func ExampleFilter_susequence() {
 		return false
 	}
 
-	dst, _ := Filter(f, s, -1)
+	dst, _ := FilterTo(nil, f, s, -1)
 
 	fmt.Println("dst =", dst)
 	fmt.Println("s =", s)
@@ -155,7 +155,7 @@ func ExampleFoldRight() {
 	}
 	initial := 5.0
 
-	val := FoldRight(nil, f, s, initial)
+	val := FoldRight(f, s, initial)
 
 	fmt.Println("val =", val)
 	fmt.Println("initial =", initial)

--- a/examples_test.go
+++ b/examples_test.go
@@ -110,7 +110,7 @@ func ExampleFilter_simple() {
 		return a > 3
 	}
 
-	dst, _ := Filter(f, s, -1)
+	dst, _ := FilterTo(nil, f, s, -1)
 
 	fmt.Println("dst =", dst)
 	fmt.Println("s =", s)
@@ -155,7 +155,7 @@ func ExampleFoldRight() {
 	}
 	initial := 5.0
 
-	val := FoldRight(f, s, initial)
+	val := FoldRight(nil, f, s, initial)
 
 	fmt.Println("val =", val)
 	fmt.Println("initial =", initial)

--- a/examples_test.go
+++ b/examples_test.go
@@ -6,6 +6,7 @@ package floats
 
 import (
 	"fmt"
+	"math"
 )
 
 // Set of examples for all the functions
@@ -101,4 +102,88 @@ func ExampleCumSum() {
 	// Output:
 	// dst = [1 -1 2 -2]
 	// s = [1 -2 3 -4]
+}
+
+func ExampleFilter_simple() {
+	s := []float64{1, 3, 2, 5, 6}
+	f := func(a float64) bool {
+		return a > 3
+	}
+
+	dst, _ := Filter(f, s, -1)
+
+	fmt.Println("dst =", dst)
+	fmt.Println("s =", s)
+	// Output:
+	// dst = [5 6]
+	// s = [1 3 2 5 6]
+}
+
+func ExampleFilter_susequence() {
+	// Let's use state magic to filter elements
+	// so the resulting list is a strictly increasing
+	// subsequence!
+
+	max := math.Inf(-1)
+	s := []float64{1, 3, 2, 6, 5}
+	f := func(a float64) bool {
+		if a > max {
+			max = a
+			return true
+		}
+
+		return false
+	}
+
+	dst, _ := Filter(f, s, -1)
+
+	fmt.Println("dst =", dst)
+	fmt.Println("s =", s)
+	// Output:
+	// dst = [1 3 6]
+	// s = [1 3 2 6 5]
+}
+
+func ExampleFoldRight() {
+	s := []float64{9, -2, 21, 4}
+	f := func(a, b float64) float64 {
+		if a < b {
+			return a * b
+		}
+
+		return a - b
+	}
+	initial := 5.0
+
+	val := FoldRight(f, s, initial)
+
+	fmt.Println("val =", val)
+	fmt.Println("initial =", initial)
+	fmt.Println("s =", s)
+	// Output:
+	// val = 11
+	// initial = 5
+	// s = [9 -2 21 4]
+}
+
+func ExampleFoldLeft() {
+	s := []float64{9, -2, 21, 4}
+	f := func(a, b float64) float64 {
+		if a < b {
+			return a * b
+		}
+
+		return a - b
+	}
+	initial := 5.0
+
+	val := FoldLeft(f, s, initial)
+
+	fmt.Println("val =", val)
+	fmt.Println("initial =", initial)
+	fmt.Println("s =", s)
+	// Output:
+	// val = 22
+	// initial = 5
+	// s = [9 -2 21 4]
 }

--- a/floats.go
+++ b/floats.go
@@ -42,21 +42,6 @@ func AddTo(dst, s, t []float64) []float64 {
 	return dst
 }
 
-// Applies a function to every element of s and stores the result in dst. If dst and s are
-// not the same size, this will panic
-//
-// This is similar to Apply, but places the result in another slice
-func ApplyTo(dst, s []float64, f func(float64) float64) []float64 {
-	if len(dst) != len(s) {
-		panic("floats: length of destination does not match length of map recipient")
-	}
-	for i, val := range s {
-		dst[i] = f(val)
-	}
-
-	return dst
-}
-
 // AddConst adds the value c to all of the values in s.
 func AddConst(c float64, s []float64) {
 	for i := range s {
@@ -108,6 +93,29 @@ func (a argsort) Less(i, j int) bool {
 func (a argsort) Swap(i, j int) {
 	a.s[i], a.s[j] = a.s[j], a.s[i]
 	a.inds[i], a.inds[j] = a.inds[j], a.inds[i]
+}
+
+// Apply applies a function f (math.Exp, math.Sin, etc.) to every element
+// of the slice s.
+func Apply(f func(float64) float64, s []float64) {
+	for i, val := range s {
+		s[i] = f(val)
+	}
+}
+
+// Applies a function to every element of s and stores the result in dst. If dst and s are
+// not the same size, this will panic
+//
+// This is similar to Apply, but places the result in another slice
+func ApplyTo(dst []float64, f func(float64) float64, s []float64) []float64 {
+	if len(dst) != len(s) {
+		panic("floats: length of destination does not match length of map recipient")
+	}
+	for i, val := range s {
+		dst[i] = f(val)
+	}
+
+	return dst
 }
 
 // Argsort sorts the elements of s while tracking their original order.

--- a/floats.go
+++ b/floats.go
@@ -713,7 +713,7 @@ func Within(s []float64, v float64) int {
 // accum = f(curr, accum)
 //
 // At each step
-func FoldRight(s []float64, accum float64, f func(float64, float64) float64) float64 {
+func FoldRight(f func(float64, float64) float64, s []float64, accum float64) float64 {
 	for j := len(s) - 1; j >= 0; j-- {
 		accum = f(s[j], accum)
 	}
@@ -730,7 +730,7 @@ func FoldRight(s []float64, accum float64, f func(float64, float64) float64) flo
 // accum = f(accum, curr)
 //
 // At each step
-func FoldLeft(s []float64, accum float64, f func(float64, float64) float64) float64 {
+func FoldLeft(f func(float64, float64) float64, s []float64, accum float64) float64 {
 	for _, val := range s {
 		accum = f(accum, val)
 	}

--- a/floats.go
+++ b/floats.go
@@ -44,8 +44,8 @@ func AddTo(dst, s, t []float64) []float64 {
 
 // AddConst adds the value c to all of the values in dst.
 func AddConst(c float64, dst []float64) {
-	for i := range s {
-		s[i] += c
+	for i := range dst {
+		dst[i] += c
 	}
 }
 

--- a/floats.go
+++ b/floats.go
@@ -680,3 +680,33 @@ func Within(s []float64, v float64) int {
 	}
 	return -1
 }
+
+// Folds a function from the right into a single value by iteratively applying a function on an accumulated value.
+// Accum is the initial accumulator value.
+//
+// This is equivalent to iterating over the list from the right and doing
+// accum = f(curr, accum)
+//
+// At each step
+func FoldRight(s []float64, accum float64, f func(float64, float64) float64) float64 {
+	for j := len(s) - 1; j >= 0; j-- {
+		accum = f(s[j], accum)
+	}
+
+	return accum
+}
+
+// Folds a function from the left into a single value by iteratively applying a function on an accumulated value.
+// Accum is the initial accumulator value.
+//
+// This is equivalent to iterating over the list from the start and doing
+// accum = f(accum, curr)
+//
+// At each step
+func FoldLeft(s []float64, accum float64, f func(float64, float64) float64) float64 {
+	for _, val := range s {
+		accum = f(accum, val)
+	}
+
+	return accum
+}

--- a/floats.go
+++ b/floats.go
@@ -710,9 +710,8 @@ func Within(s []float64, v float64) int {
 // Accum is the initial accumulator value.
 //
 // This is equivalent to iterating over the list from the right and doing
-// accum = f(curr, accum)
-//
-// At each step
+//     accum = f(curr, accum)
+// at each step.
 func FoldRight(f func(float64, float64) float64, s []float64, accum float64) float64 {
 	for j := len(s) - 1; j >= 0; j-- {
 		accum = f(s[j], accum)
@@ -727,9 +726,14 @@ func FoldRight(f func(float64, float64) float64, s []float64, accum float64) flo
 // Accum is the initial accumulator value.
 //
 // This is equivalent to iterating over the list from the start and doing
-// accum = f(accum, curr)
+//     accum = f(accum, curr)
+// at each step.
 //
-// At each step
+// For instance, the last element of CumProd could be found with:
+//     FoldLeft(func(a,b float64) float64{ return a * b}, s, 1.0)
+//
+// Or the last element of CumSum:
+//     FoldLeft(func(a,b float64) float64{ return a + b}, s, 0.0)
 func FoldLeft(f func(float64, float64) float64, s []float64, accum float64) float64 {
 	for _, val := range s {
 		accum = f(accum, val)

--- a/floats.go
+++ b/floats.go
@@ -729,3 +729,59 @@ func FoldLeft(s []float64, accum float64, f func(float64, float64) float64) floa
 
 	return accum
 }
+
+// Applies a function to every element of s and places the first k elements where
+// that function returns true in an output slice.
+//
+// If k < 0, this will return all elements that return true.
+// If k > 0, and fewer elements pass the test, this will return an error.
+//
+// Useful for, for instance, filtering all the strictly negative numbers out of a slice.
+func Filter(f func(float64) bool, s []float64, k int) ([]float64, error) {
+	out := make([]float64, 0, len(s))
+	return FilterTo(out, f, s, k)
+}
+
+// Applies a function to every element of s and places the first k elements
+// where that function returns true in dst.
+//
+// If k < 0, this will slice dst to 0 and append all
+// elements that return true. If k > 0, and fewer elements pass the test,
+// this will return an error.
+//
+// Useful for, for instance, filtering all the strictly negative numbers out of a slice.
+//
+// This is the same as Find, but it returns the actual elements instead of the indices
+func FilterTo(dst []float64, f func(float64) bool, s []float64, k int) ([]float64, error) {
+	if k == 0 {
+		return dst[:0], nil
+	}
+
+	var err error
+	dst = dst[:0]
+
+	if k < 0 {
+		for _, val := range s {
+			if f(val) {
+				dst = append(dst, val)
+			}
+		}
+	} else {
+		found := 0
+		for _, val := range s {
+			if found >= k {
+				break
+			}
+			if f(val) {
+				dst = append(dst, val)
+				found++
+			}
+		}
+
+		if found < k {
+			err = errors.New("floats: insufficient elements found")
+		}
+	}
+
+	return dst, err
+}

--- a/floats.go
+++ b/floats.go
@@ -42,10 +42,25 @@ func AddTo(dst, s, t []float64) []float64 {
 	return dst
 }
 
-// AddConst adds the scalar c to all of the values in dst.
-func AddConst(c float64, dst []float64) {
-	for i := range dst {
-		dst[i] += c
+// Applies a function to every element of s and stores the result in dst. If dst and s are
+// not the same size, this will panic
+//
+// This is similar to Apply, but places the result in another slice
+func ApplyTo(dst, s []float64, f func(float64) float64) []float64 {
+	if len(dst) != len(s) {
+		panic("floats: length of destination does not match length of map recipient")
+	}
+	for i, val := range s {
+		dst[i] = f(val)
+	}
+
+	return dst
+}
+
+// AddConst adds the value c to all of the values in s.
+func AddConst(c float64, s []float64) {
+	for i := range s {
+		s[i] += c
 	}
 }
 
@@ -681,7 +696,9 @@ func Within(s []float64, v float64) int {
 	return -1
 }
 
-// Folds a function from the right into a single value by iteratively applying a function on an accumulated value.
+// Folds a function from the right into a single value by iteratively applying a function on an
+// accumulated value.
+//
 // Accum is the initial accumulator value.
 //
 // This is equivalent to iterating over the list from the right and doing
@@ -696,7 +713,9 @@ func FoldRight(s []float64, accum float64, f func(float64, float64) float64) flo
 	return accum
 }
 
-// Folds a function from the left into a single value by iteratively applying a function on an accumulated value.
+// Folds a function from the left into a single value by iteratively applying a function on an
+// accumulated value.
+//
 // Accum is the initial accumulator value.
 //
 // This is equivalent to iterating over the list from the start and doing

--- a/floats_test.go
+++ b/floats_test.go
@@ -1117,6 +1117,33 @@ func TestFoldLeft(t *testing.T) {
 	}
 }
 
+func TestApplyTo(t *testing.T) {
+	tests := []struct {
+		s        []float64
+		f        func(float64) float64
+		expected []float64
+	}{
+		{s: []float64{1, 2, 3, 4}, f: func(a float64) float64 { return a * a }, expected: []float64{1, 4, 9, 16}},
+		{s: []float64{1, 2, 3, 4}, f: func(a float64) float64 { return 2 * a }, expected: []float64{2, 4, 6, 8}},
+		{s: []float64{1, 2, 3, 4}, f: func(a float64) float64 { return a - 1 }, expected: []float64{0, 1, 2, 3}},
+	}
+
+	for i, test := range tests {
+		dst := make([]float64, len(test.s))
+		tmp := make([]float64, len(test.s))
+		copy(tmp, test.s)
+		ApplyTo(dst, test.s, test.f)
+		if !EqualApprox(dst, test.expected, 1e-6) {
+			t.Errorf("ApplyTo failed on test %d. Got %v expected %v", i, dst, test.expected)
+		}
+
+		// Check to make sure input slice not mutated
+		if !EqualApprox(tmp, test.s, 0) {
+			t.Error("Non-dst Input slice mutated in ApplyTo")
+		}
+	}
+}
+
 func RandomSlice(l int) []float64 {
 	s := make([]float64, l)
 	for i := range s {

--- a/floats_test.go
+++ b/floats_test.go
@@ -1132,7 +1132,7 @@ func TestApplyTo(t *testing.T) {
 		dst := make([]float64, len(test.s))
 		tmp := make([]float64, len(test.s))
 		copy(tmp, test.s)
-		ApplyTo(dst, test.s, test.f)
+		ApplyTo(dst, test.f, test.s)
 		if !EqualApprox(dst, test.expected, 1e-6) {
 			t.Errorf("ApplyTo failed on test %d. Got %v expected %v", i, dst, test.expected)
 		}

--- a/floats_test.go
+++ b/floats_test.go
@@ -1117,33 +1117,6 @@ func TestFoldLeft(t *testing.T) {
 	}
 }
 
-func TestApplyTo(t *testing.T) {
-	tests := []struct {
-		s        []float64
-		f        func(float64) float64
-		expected []float64
-	}{
-		{s: []float64{1, 2, 3, 4}, f: func(a float64) float64 { return a * a }, expected: []float64{1, 4, 9, 16}},
-		{s: []float64{1, 2, 3, 4}, f: func(a float64) float64 { return 2 * a }, expected: []float64{2, 4, 6, 8}},
-		{s: []float64{1, 2, 3, 4}, f: func(a float64) float64 { return a - 1 }, expected: []float64{0, 1, 2, 3}},
-	}
-
-	for i, test := range tests {
-		dst := make([]float64, len(test.s))
-		tmp := make([]float64, len(test.s))
-		copy(tmp, test.s)
-		ApplyTo(dst, test.f, test.s)
-		if !EqualApprox(dst, test.expected, 1e-6) {
-			t.Errorf("ApplyTo failed on test %d. Got %v expected %v", i, dst, test.expected)
-		}
-
-		// Check to make sure input slice not mutated
-		if !EqualApprox(tmp, test.s, 0) {
-			t.Error("Non-dst Input slice mutated in ApplyTo")
-		}
-	}
-}
-
 func TestFilterTo(t *testing.T) {
 	tests := []struct {
 		s           []float64

--- a/floats_test.go
+++ b/floats_test.go
@@ -1090,7 +1090,7 @@ func TestFoldRight(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		got := FoldRight(test.s, test.accum, test.f)
+		got := FoldRight(test.f, test.s, test.accum)
 		if !EqualWithinAbs(got, test.expected, 1e-6) {
 			t.Errorf("FoldRight failed on test %d. Got %v expected %v", i, got, test.expected)
 		}
@@ -1110,7 +1110,7 @@ func TestFoldLeft(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		got := FoldLeft(test.s, test.accum, test.f)
+		got := FoldLeft(test.f, test.s, test.accum)
 		if !EqualWithinAbs(got, test.expected, 1e-6) {
 			t.Errorf("FoldLeft failed on test %d. Got %v expected %v", i, got, test.expected)
 		}

--- a/floats_test.go
+++ b/floats_test.go
@@ -1075,7 +1075,46 @@ func TestWithin(t *testing.T) {
 			t.Errorf("Case %v: Idx mismatch. Want: %v, got: %v", i, test.idx, idx)
 		}
 	}
+}
 
+func TestFoldRight(t *testing.T) {
+	tests := []struct {
+		s        []float64
+		f        func(float64, float64) float64
+		accum    float64
+		expected float64
+	}{
+		{s: []float64{1, 2, 3, 4}, f: func(a, b float64) float64 { return a - b }, accum: 3, expected: 1},
+		{s: []float64{1, 2, 3, 4}, f: func(a, b float64) float64 { return a + b }, accum: 100, expected: 110},
+		{s: []float64{1, 2, 3, 4}, f: func(a, b float64) float64 { return (a * b) / 2 }, accum: 6, expected: 9},
+	}
+
+	for i, test := range tests {
+		got := FoldRight(test.s, test.accum, test.f)
+		if !EqualWithinAbs(got, test.expected, 1e-6) {
+			t.Errorf("FoldRight failed on test %d. Got %v expected %v", i, got, test.expected)
+		}
+	}
+}
+
+func TestFoldLeft(t *testing.T) {
+	tests := []struct {
+		s        []float64
+		f        func(float64, float64) float64
+		accum    float64
+		expected float64
+	}{
+		{s: []float64{1, 2, 3, 4}, f: func(a, b float64) float64 { return a - b }, accum: 3, expected: -7},
+		{s: []float64{1, 2, 3, 4}, f: func(a, b float64) float64 { return a + b }, accum: 100, expected: 110},
+		{s: []float64{1, 2, 3, 4}, f: func(a, b float64) float64 { return (a * b) / 2 }, accum: 6, expected: 9},
+	}
+
+	for i, test := range tests {
+		got := FoldLeft(test.s, test.accum, test.f)
+		if !EqualWithinAbs(got, test.expected, 1e-6) {
+			t.Errorf("FoldLeft failed on test %d. Got %v expected %v", i, got, test.expected)
+		}
+	}
 }
 
 func RandomSlice(l int) []float64 {


### PR DESCRIPTION
The primary purpose of this was FoldRight and FoldLeft. If desired, I can make them closer to CumProd and CumSum by storing the current cumulative value at each step (though personally I don't like that for fold).

I also added a Filter, which is similar to Find, except it just filters the list for you instead of just returning indices. This is slightly redundant, but then, Count is redundant if you do `len(Find(dst, f, s, -1))` as well.

Finally, I added ApplyTo since it was a bit odd we didn't have a way to map functions and place the result in a **different** slice.

I can remove anything we decide we don't want.

All functions have tests (except Filter because it's a simple passthrough to FilterTo), as well as examples. (One of the filter ones is pretty cool actually -- it filters the slice so that the new slice is a strictly increasing subsequence).