### PR TITLE
Use asm.Daxpy* functions

### DIFF
--- a/floats.go
+++ b/floats.go
@@ -722,9 +722,7 @@ func Sub(dst, s []float64) {
 	if len(dst) != len(s) {
 		panic("floats: length of the slices do not match")
 	}
-	for i, val := range s {
-		dst[i] -= val
-	}
+	asm.DaxpyUnitaryTo(dst, -1, s, dst)
 }
 
 // SubTo subtracts, element-wise, the elements of t from s and
@@ -736,9 +734,7 @@ func SubTo(dst, s, t []float64) []float64 {
 	if len(dst) != len(s) {
 		panic("floats: length of destination does not match length of subtractor")
 	}
-	for i, val := range t {
-		dst[i] = s[i] - val
-	}
+	asm.DaxpyUnitaryTo(dst, -1, t, s)
 	return dst
 }
 

--- a/floats.go
+++ b/floats.go
@@ -24,9 +24,7 @@ func Add(dst, s []float64) {
 	if len(dst) != len(s) {
 		panic("floats: length of the slices do not match")
 	}
-	for i, val := range s {
-		dst[i] += val
-	}
+	asm.DaxpyUnitaryTo(dst, 1, s, dst)
 }
 
 // AddTo adds, element-wise, the elements of s and t and
@@ -38,9 +36,7 @@ func AddTo(dst, s, t []float64) []float64 {
 	if len(dst) != len(s) {
 		panic("floats: length of destination does not match length of adder")
 	}
-	for i, val := range t {
-		dst[i] = s[i] + val
-	}
+	asm.DaxpyUnitaryTo(dst, 1, s, t)
 	return dst
 }
 

--- a/floats.go
+++ b/floats.go
@@ -57,7 +57,7 @@ func AddScaled(dst []float64, alpha float64, s []float64) {
 	if len(dst) != len(s) {
 		panic("floats: length of destination and source to not match")
 	}
-	asm.DaxpyUnitary(alpha, s, dst, dst)
+	asm.DaxpyUnitaryTo(dst, alpha, s, dst)
 }
 
 // AddScaledTo performs dst = y + alpha * s, where alpha is a scalar,
@@ -69,7 +69,7 @@ func AddScaledTo(dst, y []float64, alpha float64, s []float64) []float64 {
 	if len(dst) != len(s) || len(dst) != len(y) {
 		panic("floats: lengths of slices do not match")
 	}
-	asm.DaxpyUnitary(alpha, s, y, dst)
+	asm.DaxpyUnitaryTo(dst, alpha, s, y)
 	return dst
 }
 

--- a/floats_test.go
+++ b/floats_test.go
@@ -1327,6 +1327,21 @@ func BenchmarkAddHuge(b *testing.B) {
 	benchmarkAdd(b, Huge)
 }
 
+func benchmarkAddTo(b *testing.B, size int) {
+	s1 := randomSlice(size)
+	s2 := randomSlice(size)
+	dst := randomSlice(size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		AddTo(dst, s1, s2)
+	}
+}
+
+func BenchmarkAddToSmall(b *testing.B) { benchmarkAddTo(b, Small) }
+func BenchmarkAddToMed(b *testing.B)   { benchmarkAddTo(b, Medium) }
+func BenchmarkAddToLarge(b *testing.B) { benchmarkAddTo(b, Large) }
+func BenchmarkAddToHuge(b *testing.B)  { benchmarkAddTo(b, Huge) }
+
 func benchmarkLogSumExp(b *testing.B, size int) {
 	s := randomSlice(size)
 	b.ResetTimer()

--- a/floats_test.go
+++ b/floats_test.go
@@ -1342,6 +1342,35 @@ func BenchmarkAddToMed(b *testing.B)   { benchmarkAddTo(b, Medium) }
 func BenchmarkAddToLarge(b *testing.B) { benchmarkAddTo(b, Large) }
 func BenchmarkAddToHuge(b *testing.B)  { benchmarkAddTo(b, Huge) }
 
+func benchmarkSub(b *testing.B, size int) {
+	s1 := randomSlice(size)
+	s2 := randomSlice(size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Sub(s1, s2)
+	}
+}
+
+func BenchmarkSubSmall(b *testing.B) { benchmarkSub(b, Small) }
+func BenchmarkSubMed(b *testing.B)   { benchmarkSub(b, Medium) }
+func BenchmarkSubLarge(b *testing.B) { benchmarkSub(b, Large) }
+func BenchmarkSubHuge(b *testing.B)  { benchmarkSub(b, Huge) }
+
+func benchmarkSubTo(b *testing.B, size int) {
+	s1 := randomSlice(size)
+	s2 := randomSlice(size)
+	dst := randomSlice(size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SubTo(dst, s1, s2)
+	}
+}
+
+func BenchmarkSubToSmall(b *testing.B) { benchmarkSubTo(b, Small) }
+func BenchmarkSubToMed(b *testing.B)   { benchmarkSubTo(b, Medium) }
+func BenchmarkSubToLarge(b *testing.B) { benchmarkSubTo(b, Large) }
+func BenchmarkSubToHuge(b *testing.B)  { benchmarkSubTo(b, Huge) }
+
 func benchmarkLogSumExp(b *testing.B, size int) {
 	s := randomSlice(size)
 	b.ResetTimer()


### PR DESCRIPTION
Depends on gonum/internal#16

```
AddSmall           11.5ns ± 0%   9.8ns ± 0%  -14.52%          (p=0.029 n=4+4)
AddMed              869ns ± 0%   306ns ± 0%  -64.79%          (p=0.029 n=4+4)
AddLarge           93.3µs ± 0%  57.0µs ± 1%  -38.89%          (p=0.029 n=4+4)
AddHuge            14.4ms ± 0%  13.4ms ± 0%   -7.04%          (p=0.029 n=4+4)
AddToSmall         13.3ns ± 0%  12.1ns ± 0%   -9.40%          (p=0.029 n=4+4)
AddToMed            871ns ± 0%   309ns ± 0%  -64.52%          (p=0.029 n=4+4)
AddToLarge          101µs ± 1%    70µs ± 0%  -31.09%          (p=0.029 n=4+4)
AddToHuge          18.1ms ± 0%  18.2ms ± 0%   +0.56%          (p=0.029 n=4+4)
SubSmall           11.5ns ± 0%   9.9ns ± 0%  -14.24%          (p=0.029 n=4+4)
SubMed              869ns ± 0%   306ns ± 0%  -64.79%          (p=0.029 n=4+4)
SubLarge           93.3µs ± 0%  56.0µs ± 0%  -39.94%          (p=0.029 n=4+4)
SubHuge            14.5ms ± 0%  13.4ms ± 0%   -7.19%          (p=0.029 n=4+4)
SubToSmall         12.6ns ± 0%  12.0ns ± 0%   -4.76%          (p=0.029 n=4+4)
SubToMed            870ns ± 0%   309ns ± 0%  -64.48%          (p=0.029 n=4+4)
SubToLarge          100µs ± 0%    70µs ± 0%  -29.83%          (p=0.029 n=4+4)
SubToHuge          18.0ms ± 0%  18.2ms ± 0%   +1.39%          (p=0.029 n=4+4)
```