### PR TITLE
Use asm.DscalUnitary in Scale

### DIFF
--- a/floats.go
+++ b/floats.go
@@ -691,8 +691,8 @@ func Same(s, t []float64) bool {
 
 // Scale multiplies every element in dst by the scalar c.
 func Scale(c float64, dst []float64) {
-	for i := range dst {
-		dst[i] *= c
+	if len(dst) > 0 {
+		asm.DscalUnitary(c, dst)
 	}
 }
 

--- a/floats_test.go
+++ b/floats_test.go
@@ -1444,3 +1444,15 @@ func BenchmarkAddScaledToLarge(b *testing.B) {
 func BenchmarkAddScaledToHuge(b *testing.B) {
 	benchmarkAddScaledTo(b, Huge)
 }
+
+func benchmarkScale(b *testing.B, size int) {
+	dst := randomSlice(size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Scale(2.0, dst)
+	}
+}
+func BenchmarkScaleSmall(b *testing.B)  { benchmarkScale(b, Small) }
+func BenchmarkScaleMedium(b *testing.B) { benchmarkScale(b, Medium) }
+func BenchmarkScaleLarge(b *testing.B)  { benchmarkScale(b, Large) }
+func BenchmarkScaleHuge(b *testing.B)   { benchmarkScale(b, Huge) }


### PR DESCRIPTION
```
name         old time/op  new time/op  delta
ScaleSmall   10.5ns ± 0%   8.0ns ± 0%  -24.29%  (p=0.029 n=4+4)
ScaleMedium   691ns ± 0%   170ns ± 0%  -75.40%  (p=0.029 n=4+4)
ScaleLarge   71.5µs ± 0%  43.3µs ± 0%  -39.41%  (p=0.029 n=4+4)
ScaleHuge    10.0ms ± 0%   8.2ms ± 1%  -18.16%  (p=0.029 n=4+4)
```