### PR TITLE
floats: use f64 functions where available

### DIFF
--- a/floats.go
+++ b/floats.go
@@ -131,11 +131,7 @@ func CumProd(dst, s []float64) []float64 {
 	if len(dst) == 0 {
 		return dst
 	}
-	dst[0] = s[0]
-	for i := 1; i < len(s); i++ {
-		dst[i] = dst[i-1] * s[i]
-	}
-	return dst
+	return f64.CumProd(dst, s)
 }
 
 // CumSum finds the cumulative sum of the first i elements in
@@ -151,11 +147,7 @@ func CumSum(dst, s []float64) []float64 {
 	if len(dst) == 0 {
 		return dst
 	}
-	dst[0] = s[0]
-	for i := 1; i < len(s); i++ {
-		dst[i] = dst[i-1] + s[i]
-	}
-	return dst
+	return f64.CumSum(dst, s)
 }
 
 // Distance computes the L-norm of s - t. See Norm for special cases.
@@ -203,9 +195,7 @@ func Div(dst, s []float64) {
 	if len(dst) != len(s) {
 		panic("floats: slice lengths do not match")
 	}
-	for i, val := range s {
-		dst[i] /= val
-	}
+	f64.Div(dst, s)
 }
 
 // DivTo performs element-wise division s / t
@@ -215,10 +205,7 @@ func DivTo(dst, s, t []float64) []float64 {
 	if len(s) != len(t) || len(dst) != len(t) {
 		panic("floats: slice lengths do not match")
 	}
-	for i, val := range t {
-		dst[i] = s[i] / val
-	}
-	return dst
+	return f64.DivTo(dst, s, t)
 }
 
 // Dot computes the dot product of s1 and s2, i.e.

--- a/floats_test.go
+++ b/floats_test.go
@@ -1335,6 +1335,59 @@ func BenchmarkAddToMed(b *testing.B)   { benchmarkAddTo(b, Medium) }
 func BenchmarkAddToLarge(b *testing.B) { benchmarkAddTo(b, Large) }
 func BenchmarkAddToHuge(b *testing.B)  { benchmarkAddTo(b, Huge) }
 
+func benchmarkCumProd(b *testing.B, size int) {
+	s := randomSlice(size)
+	dst := randomSlice(size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CumProd(dst, s)
+	}
+}
+func BenchmarkCumProdSmall(b *testing.B) { benchmarkCumProd(b, Small) }
+func BenchmarkCumProdMed(b *testing.B)   { benchmarkCumProd(b, Medium) }
+func BenchmarkCumProdLarge(b *testing.B) { benchmarkCumProd(b, Large) }
+func BenchmarkCumProdHuge(b *testing.B)  { benchmarkCumProd(b, Huge) }
+
+func benchmarkCumSum(b *testing.B, size int) {
+	s := randomSlice(size)
+	dst := randomSlice(size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CumSum(dst, s)
+	}
+}
+func BenchmarkCumSumSmall(b *testing.B) { benchmarkCumSum(b, Small) }
+func BenchmarkCumSumMed(b *testing.B)   { benchmarkCumSum(b, Medium) }
+func BenchmarkCumSumLarge(b *testing.B) { benchmarkCumSum(b, Large) }
+func BenchmarkCumSumHuge(b *testing.B)  { benchmarkCumSum(b, Huge) }
+
+func benchmarkDiv(b *testing.B, size int) {
+	s := randomSlice(size)
+	dst := randomSlice(size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Div(dst, s)
+	}
+}
+func BenchmarkDivSmall(b *testing.B) { benchmarkDiv(b, Small) }
+func BenchmarkDivMed(b *testing.B)   { benchmarkDiv(b, Medium) }
+func BenchmarkDivLarge(b *testing.B) { benchmarkDiv(b, Large) }
+func BenchmarkDivHuge(b *testing.B)  { benchmarkDiv(b, Huge) }
+
+func benchmarkDivTo(b *testing.B, size int) {
+	s1 := randomSlice(size)
+	s2 := randomSlice(size)
+	dst := randomSlice(size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DivTo(dst, s1, s2)
+	}
+}
+func BenchmarkDivToSmall(b *testing.B) { benchmarkDivTo(b, Small) }
+func BenchmarkDivToMed(b *testing.B)   { benchmarkDivTo(b, Medium) }
+func BenchmarkDivToLarge(b *testing.B) { benchmarkDivTo(b, Large) }
+func BenchmarkDivToHuge(b *testing.B)  { benchmarkDivTo(b, Huge) }
+
 func benchmarkSub(b *testing.B, size int) {
 	s1 := randomSlice(size)
 	s2 := randomSlice(size)


### PR DESCRIPTION
@btracey Please take a look.

I left `Add` calling `f64.AxpyUnitaryTo` rather than changing to `f64.Add` as the benchmark impact is unclear; it swings ±10% with low p (the benchmarks below show a 2-9% improvement without touching it!).

```
name                 old time/op  new time/op  delta
MinSmall-8           14.9ns ± 1%  16.2ns ± 5%   +8.47%  (p=0.000 n=7+8)
MinMed-8             1.09µs ± 2%  1.10µs ± 4%     ~     (p=0.306 n=9+9)
MinLarge-8            104µs ± 2%   103µs ± 0%     ~     (p=1.000 n=10+8)
MinHuge-8            10.8ms ± 2%  10.9ms ± 1%     ~     (p=0.481 n=8+9)
AddSmall-8           10.5ns ±11%   9.6ns ± 1%   -9.00%  (p=0.000 n=10+8)
AddMed-8              291ns ± 6%   274ns ± 1%   -5.94%  (p=0.001 n=10+10)
AddLarge-8           41.3µs ± 1%  40.4µs ± 1%   -2.20%  (p=0.000 n=10+10)
AddHuge-8            14.8ms ± 0%  14.5ms ± 0%   -2.15%  (p=0.000 n=10+10)
AddToSmall-8         11.1ns ± 1%  11.1ns ± 2%     ~     (p=0.184 n=10+10)
AddToMed-8            280ns ± 2%   304ns ± 1%   +8.82%  (p=0.000 n=9+10)
AddToLarge-8         48.2µs ± 2%  47.8µs ± 1%   -0.92%  (p=0.027 n=8+10)
AddToHuge-8          19.7ms ± 0%  19.4ms ± 0%   -1.92%  (p=0.000 n=9+10)
CumProdSmall-8       13.9ns ± 3%  13.2ns ± 2%   -4.48%  (p=0.000 n=10+10)
CumProdMed-8         4.21µs ±13%  2.42µs ± 6%  -42.55%  (p=0.000 n=10+9)
CumProdLarge-8        271µs ± 1%    69µs ± 2%  -74.61%  (p=0.000 n=10+9)
CumProdHuge-8        28.3ms ± 4%  14.4ms ± 2%  -48.94%  (p=0.000 n=10+9)
CumSumSmall-8        14.3ns ± 1%  14.2ns ± 0%     ~     (p=0.103 n=8+8)
CumSumMed-8          2.64µs ± 1%  0.82µs ± 0%  -69.02%  (p=0.000 n=9+8)
CumSumLarge-8         269µs ± 1%    75µs ± 4%  -72.09%  (p=0.000 n=9+9)
CumSumHuge-8         27.6ms ± 1%  14.5ms ± 1%  -47.47%  (p=0.000 n=9+9)
DivSmall-8           11.9ns ± 1%   9.7ns ± 0%  -18.65%  (p=0.000 n=10+8)
DivMed-8             1.19µs ± 0%  0.59µs ± 0%  -50.56%  (p=0.000 n=9+10)
DivLarge-8            120µs ± 3%    59µs ± 1%  -50.80%  (p=0.000 n=10+9)
DivHuge-8            16.1ms ±11%  14.5ms ± 0%   -9.88%  (p=0.000 n=10+8)
DivToSmall-8         11.8ns ± 1%  12.2ns ± 1%   +4.12%  (p=0.000 n=10+9)
DivToMed-8           1.17µs ± 0%  0.58µs ± 0%  -50.18%  (p=0.000 n=9+8)
DivToLarge-8          118µs ± 1%    59µs ± 0%  -50.15%  (p=0.000 n=9+9)
DivToHuge-8          19.8ms ± 1%  19.3ms ± 0%   -2.15%  (p=0.000 n=9+9)
SubSmall-8           9.57ns ± 1%  9.57ns ± 1%     ~     (p=0.401 n=10+10)
SubMed-8              304ns ± 1%   272ns ± 1%  -10.41%  (p=0.000 n=9+9)
SubLarge-8           40.9µs ± 1%  40.5µs ± 1%     ~     (p=0.165 n=10+10)
SubHuge-8            14.1ms ± 0%  14.5ms ± 0%   +2.69%  (p=0.000 n=10+10)
SubToSmall-8         11.0ns ± 2%  11.0ns ± 1%     ~     (p=0.752 n=9+10)
SubToMed-8            305ns ± 0%   292ns ± 1%   -4.11%  (p=0.000 n=8+10)
SubToLarge-8         48.7µs ± 0%  47.5µs ± 1%   -2.54%  (p=0.000 n=10+9)
SubToHuge-8          18.9ms ± 0%  19.4ms ± 1%   +2.60%  (p=0.000 n=10+9)
LogSumExpSmall-8      219ns ± 2%   219ns ± 2%     ~     (p=0.812 n=9+9)
LogSumExpMed-8       16.4µs ± 1%  16.2µs ± 1%   -1.21%  (p=0.001 n=8+10)
LogSumExpLarge-8     1.64ms ± 2%  1.61ms ± 2%   -1.57%  (p=0.001 n=10+9)
LogSumExpHuge-8       164ms ± 1%   163ms ± 5%     ~     (p=0.156 n=9+10)
DotSmall-8           8.79ns ± 2%  8.70ns ± 1%   -0.92%  (p=0.006 n=9+8)
DotMed-8              296ns ± 1%   297ns ± 1%     ~     (p=0.566 n=9+10)
DotLarge-8           35.3µs ± 1%  35.0µs ± 1%     ~     (p=0.052 n=10+10)
DotHuge-8            10.6ms ± 0%  10.5ms ± 1%   -0.86%  (p=0.000 n=10+9)
AddScaledToSmall-8   11.5ns ± 0%  11.5ns ± 2%     ~     (p=1.000 n=6+10)
AddScaledToMedium-8   276ns ± 1%   307ns ± 2%  +11.03%  (p=0.000 n=10+10)
AddScaledToLarge-8   49.3µs ± 1%  47.7µs ± 1%   -3.22%  (p=0.000 n=10+10)
AddScaledToHuge-8    19.7ms ± 0%  19.5ms ± 2%   -1.30%  (p=0.023 n=10+10)
ScaleSmall-8         7.38ns ± 1%  7.21ns ± 0%   -2.29%  (p=0.000 n=10+8)
ScaleMedium-8         160ns ± 0%   159ns ± 0%   -0.31%  (p=0.007 n=10+7)
ScaleLarge-8         25.5µs ± 1%  25.2µs ± 0%   -1.23%  (p=0.000 n=10+9)
ScaleHuge-8          10.0ms ± 9%   9.5ms ± 6%   -4.92%  (p=0.019 n=10+10)
```

Fixes #66.